### PR TITLE
Add functions to check if user has running processes and to sigterm/kill all processes of a user

### DIFF
--- a/src/umgmt/user.c
+++ b/src/umgmt/user.c
@@ -571,8 +571,8 @@ int um_user_has_running_proc(const um_user_t *user, bool *running)
 int um_user_kill_all_proc(const um_user_t *user)
 {
     // set but unchanged, required because of 'user_processes()' function signature
-    bool *running;
-    return user_processes(user, running, true);
+    bool running;
+    return user_processes(user, &running, true);
 }
 
 /**

--- a/src/umgmt/user.c
+++ b/src/umgmt/user.c
@@ -548,6 +548,19 @@ long int um_user_get_flags(const um_user_t *user)
 }
 
 /**
+ * Check if an user has any running processes / check if user is logged in
+ *
+ * @param user User to use.
+ *
+ * @return Error code - 0 on success.
+ *
+ */
+int um_user_has_running_proc(const um_user_t *user)
+{
+    return user_processes(user, PROC_CHECK);
+}
+
+/**
  * Kill all of user's processes
  *
  * @param user User to use.

--- a/src/umgmt/user.h
+++ b/src/umgmt/user.h
@@ -318,6 +318,16 @@ long int um_user_get_inactive_days(const um_user_t *user);
 long int um_user_get_expiration(const um_user_t *user);
 
 /**
+ * Check if an user has any running processes
+ *
+ * @param user User to use.
+ *
+ * @return Error code - 0 on success.
+ *
+ */
+int um_user_has_running_proc(const um_user_t *user);
+
+/**
  * Kill all of user's processes. Recommended before user deletion on system
  *
  * @param user User to use.

--- a/src/umgmt/user.h
+++ b/src/umgmt/user.h
@@ -19,11 +19,6 @@
 #include <shadow.h>
 #include <stdbool.h>
 
-typedef enum {
-    PROC_CHECK,  // check if user has running processes
-    PROC_TERM    // SIGTERM all processes, automatic fallback to SIGKILL
-} process_operations;
-
 /**
  * Allocate new user.
  *

--- a/src/umgmt/user.h
+++ b/src/umgmt/user.h
@@ -18,6 +18,11 @@
 #include <pwd.h>
 #include <shadow.h>
 
+typedef enum {
+    PROC_CHECK,  // check if user has running processes
+    PROC_TERM    // SIGTERM all processes, automatic fallback to SIGKILL
+} process_operations;
+
 /**
  * Allocate new user.
  *
@@ -311,6 +316,16 @@ long int um_user_get_inactive_days(const um_user_t *user);
  *
  */
 long int um_user_get_expiration(const um_user_t *user);
+
+/**
+ * Kill all of user's processes. Recommended before user deletion on system
+ *
+ * @param user User to use.
+ *
+ * @return Error code - 0 on success.
+ *
+ */
+int um_user_kill_all_proc(const um_user_t *user);
 
 /**
  * Get user reserved flags.

--- a/src/umgmt/user.h
+++ b/src/umgmt/user.h
@@ -17,6 +17,7 @@
 
 #include <pwd.h>
 #include <shadow.h>
+#include <stdbool.h>
 
 typedef enum {
     PROC_CHECK,  // check if user has running processes
@@ -325,7 +326,7 @@ long int um_user_get_expiration(const um_user_t *user);
  * @return Error code - 0 on success.
  *
  */
-int um_user_has_running_proc(const um_user_t *user);
+int um_user_has_running_proc(const um_user_t *user, bool *running);
 
 /**
  * Kill all of user's processes. Recommended before user deletion on system


### PR DESCRIPTION
The following functions have been added because deleting an user from the system should not be done if the affected user has open processes or is logged in.
(ofc can be used for other stuff as well, not only when a user has to be deleted)

both functions below depend on `user_processes()` which takes the user as an argument and the operation that will be done. `process_operations` can be either `PROC_CHECK` to only check if the user has any active process. If one is found, the function returns 0, no more running processes are checked. If `process_operations` is `PROC_TERM`, it will terminate all found processes. It (`kill()`) tries `SIGTERM` before doing `SIGKILL` so the process has a chance to do a graceful exit.

`um_user_has_running_proc()`
is doing what the command `userdel` would do: check if an user has any open processes to determine if the user is logged in or not. Compared to `userdel` we do not check the file `/var/run/utmp` since it does not always have the information if an user is logged in or not. For example: login via `su username` and run in another terminal on that machine `who`. The user `username` does not show up there. Reason: every application *can* write into `utmp` but it's not mandatory.


`um_user_kill_all_proc()`
is killing all processes of an user.

no new dependencies